### PR TITLE
update to allow macOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "EmojiPicker",
-    platforms: [.iOS(.v15)],
+    platforms: [.iOS(.v15),.macOS(.v12)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
This works acceptably well with macOS as long as the platform is declared:

<img width="616" alt="Screenshot 2024-12-10 at 19 20 40" src="https://github.com/user-attachments/assets/64e7f472-d49f-47ac-a259-95dcb0c88509">

However, without explicitly declaring `.macos(.v12)` the build fails. Making only this one change fixes the dependency for multi-platform use cases.